### PR TITLE
Publish to NPM GitHub Action is added

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,31 @@
+name: Publish to NPM
+
+on:
+  release:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: ./.github/workflows/run-tests.yml
+    name: Run Tests
+
+  build-and-publish:
+    name: Build and Publish
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org/
+      - run: |
+          yarn install
+          yarn prebuild
+          yarn build
+        name: Build
+      - run: npm publish --access public --dry-run
+        name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,6 +20,7 @@ on:
       - build-constants.js
       - .babelrc
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,9 @@
-test
+src/
+test/
+browser-test/
+.github/
 .babelrc
+.yarn*
+.eslintrc
+build-constants.js
+rollup.config.js


### PR DESCRIPTION
- **Updated .npmignore**
- **Marked run-tests action as reusable**
- **Added npm-publish github action (dry-run only for now)**
